### PR TITLE
1.21.1 port

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.6-SNAPSHOT'
+    id 'fabric-loom' version '1.9-SNAPSHOT'
     id 'maven-publish'
 }
 
@@ -41,7 +41,7 @@ processResources {
     }
 }
 
-def targetJavaVersion = 17
+def targetJavaVersion = 21
 tasks.withType(JavaCompile).configureEach {
     // ensure that the encoding is set to UTF-8, no matter what the system default is
     // this fixes some edge cases with special characters not displaying correctly

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,15 +4,15 @@ org.gradle.parallel=true
 
 # Fabric Properties
 	# check these on https://modmuss50.me/fabric.html
-	minecraft_version=1.20.1
-	yarn_mappings=1.20.1+build.10
-	loader_version=0.16.4
+	minecraft_version=1.21.1
+	yarn_mappings=1.21.1+build.3
+	loader_version=0.16.10
 
 # Mod Properties
-	mod_version = 1.0.2
+	mod_version = 1.0.3
 	maven_group = athebyne.exclusionslib
 	archives_base_name = exclusions_lib
 
 # Dependencies
 	# check this on https://modmuss50.me/fabric.html
-	fabric_version=0.92.2+1.20.1
+	fabric_version=0.115.0+1.21.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/net/athebyne/exclusions_lib/ExclusionsLib.java
+++ b/src/main/java/net/athebyne/exclusions_lib/ExclusionsLib.java
@@ -1,8 +1,8 @@
 package net.athebyne.exclusions_lib;
+
 import net.athebyne.exclusions_lib.predicates.OverlapsStructureBlockPredicate;
 import net.fabricmc.api.ModInitializer;
-import net.minecraft.registry.Registries;
-import net.minecraft.registry.Registry;
+import net.minecraft.registry.*;
 import net.minecraft.util.Identifier;
 import net.minecraft.world.gen.blockpredicate.BlockPredicateType;
 import org.slf4j.Logger;
@@ -12,9 +12,9 @@ public class ExclusionsLib implements ModInitializer {
     public static final String MOD_ID = "exclusions_lib";
     public static BlockPredicateType<OverlapsStructureBlockPredicate> OVERLAPS_STRUCTURE;
     public static final Logger LOGGER = LoggerFactory.getLogger("Exclusions Lib");
+
     @Override
     public void onInitialize() {
-        OVERLAPS_STRUCTURE = Registry.register(Registries.BLOCK_PREDICATE_TYPE, new Identifier(MOD_ID, "overlaps_structure"), () -> OverlapsStructureBlockPredicate.CODEC);
-
+        OVERLAPS_STRUCTURE = Registry.register(Registries.BLOCK_PREDICATE_TYPE, Identifier.of(MOD_ID, "overlaps_structure"), () -> OverlapsStructureBlockPredicate.CODEC);
     }
 }

--- a/src/main/java/net/athebyne/exclusions_lib/mixin/TagEntryMixin.java
+++ b/src/main/java/net/athebyne/exclusions_lib/mixin/TagEntryMixin.java
@@ -1,19 +1,15 @@
 package net.athebyne.exclusions_lib.mixin;
 
 
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.mojang.datafixers.kinds.App;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.athebyne.exclusions_lib.extensions.TagEntryExclusionHolder;
 import net.minecraft.registry.tag.TagEntry;
 import net.minecraft.util.Identifier;
-import org.spongepowered.asm.mixin.Final;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 
 import java.util.Objects;
 import java.util.function.Function;
@@ -34,23 +30,23 @@ public abstract class TagEntryMixin implements TagEntryExclusionHolder {
     @Unique
     private Boolean excluded;
 
-    @WrapOperation(method = "<clinit>", at = @At(value = "INVOKE", target = "Lcom/mojang/serialization/codecs/RecordCodecBuilder;create(Ljava/util/function/Function;)Lcom/mojang/serialization/Codec;"))
-    private static <O> Codec<O> wrap_create(
-            Function<RecordCodecBuilder.Instance<O>, ? extends App<RecordCodecBuilder.Mu<O>, O>> builder,
-            Operation<Codec<O>> original) {
-        return original.call(
-                TagEntryMixin.codecBuilder(builder));
+    @ModifyArg(method = "<clinit>", at = @At(value = "INVOKE", target = "Lcom/mojang/serialization/codecs/RecordCodecBuilder;create(Ljava/util/function/Function;)Lcom/mojang/serialization/Codec;"))
+    private static <O> Function<RecordCodecBuilder.Instance<O>, ? extends App<RecordCodecBuilder.Mu<O>, O>> wrap_create(
+            Function<RecordCodecBuilder.Instance<O>, ? extends App<RecordCodecBuilder.Mu<O>, O>> builder) {
+        return TagEntryMixin.codecBuilder(builder);
     }
+
     @Unique
     private static <O> Function<RecordCodecBuilder.Instance<O>, ? extends App<RecordCodecBuilder.Mu<O>, O>> codecBuilder(Function<RecordCodecBuilder.Instance<O>, ? extends App<RecordCodecBuilder.Mu<O>, O>> builder) {
         return instance -> instance.group(
-                RecordCodecBuilder.mapCodec(builder).forGetter(Function.identity()), Codec.BOOL.optionalFieldOf("excluded", false)
-                        .forGetter(exclusion -> (((TagEntryExclusionHolder) exclusion).exclusionsLib$isExcluded()))
+                RecordCodecBuilder.mapCodec(builder).forGetter(Function.identity()),
+                Codec.BOOL.optionalFieldOf("excluded", false).forGetter(exclusion -> (((TagEntryExclusionHolder) exclusion).exclusionsLib$isExcluded()))
         ).apply(instance, (exclusion, boolField) -> {
             ((TagEntryExclusionHolder) exclusion).exclusionsLib$setExcluded(boolField);
             return exclusion;
         });
     }
+
     @Override
     public Boolean exclusionsLib$isExcluded()
     {
@@ -68,17 +64,18 @@ public abstract class TagEntryMixin implements TagEntryExclusionHolder {
     {
         return this.tag;
     }
+
     @Override
     public boolean exclusionsLib$isRequired()
     {
         return this.required;
     }
-    @Override public Identifier exclusionsLib$getId()
+
+    @Override
+    public Identifier exclusionsLib$getId()
     {
         return this.id;
     }
-
-
 
 }
 

--- a/src/main/java/net/athebyne/exclusions_lib/mixin/TagGroupLoaderMixin.java
+++ b/src/main/java/net/athebyne/exclusions_lib/mixin/TagGroupLoaderMixin.java
@@ -1,20 +1,18 @@
 package net.athebyne.exclusions_lib.mixin;
 
 import com.google.common.collect.ImmutableSet;
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.injector.wrapoperation.*;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 import net.athebyne.exclusions_lib.ExclusionsLib;
 import net.athebyne.exclusions_lib.extensions.TagEntryExclusionHolder;
-import net.minecraft.registry.tag.TagEntry;
-import net.minecraft.registry.tag.TagGroupLoader;
+import net.minecraft.registry.tag.*;
 import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -27,36 +25,27 @@ public class TagGroupLoaderMixin {
     )
     private <T> boolean exclusionsLib$removeEntry(TagEntry entry, TagEntry.ValueGetter<T> valueGetter,  Consumer<T> idConsumer, Operation<Boolean> original, TagEntry.ValueGetter<T> valueGetter1, List<TagGroupLoader.TrackedEntry> entries, @Local LocalRef<ImmutableSet.Builder<T>> builder)
     {
-        if(((TagEntryExclusionHolder)entry).exclusionsLib$isExcluded())
+        TagEntryExclusionHolder holder = (TagEntryExclusionHolder) entry;
+        if (!holder.exclusionsLib$isExcluded()) return original.call(entry, valueGetter, idConsumer);
+
+	    ExclusionsLib.LOGGER.info("[Exclusions Lib] The Following Tag has been detected: {}", entry);
+        List<T> list = new ArrayList<>(builder.get().build());
+        Identifier id = holder.exclusionsLib$getId();
+        boolean required = holder.exclusionsLib$isRequired();
+        if (holder.exclusionsLib$isTag())
         {
-            ExclusionsLib.LOGGER.info("[Exclusions Lib] The Following Tag has been detected: " + entry);
-            List<T> list = new java.util.ArrayList<>(builder.get().build().stream().toList());
-            Identifier id = ((TagEntryExclusionHolder)entry).exclusionsLib$getId();
-            boolean required = ((TagEntryExclusionHolder)entry).exclusionsLib$isRequired();
-            if(((TagEntryExclusionHolder)entry).exclusionsLib$isTag())
-            {
-                Collection<T> collection = valueGetter.tag(id);
-                if (collection == null) {
-                    return !required;
-                }
-                list.removeAll(collection);
-            }
-            else
-            {
-                T object = valueGetter.direct(id);
-                if (object == null) {
-                    return !required;
-                }
-                list.removeAll(Collections.singleton(object));
-            }
-            builder.set(new ImmutableSet.Builder<T>().addAll(list));
-            return true;
+            Collection<T> collection = valueGetter.tag(id);
+            if (collection == null) return !required;
+            list.removeAll(collection);
         }
         else
         {
-            return original.call(entry,valueGetter,idConsumer);
+            T object = valueGetter.direct(id);
+            if (object == null) return !required;
+            list.remove(object);
         }
+        builder.set(new ImmutableSet.Builder<T>().addAll(list));
+        return true;
     }
-
 
 }

--- a/src/main/java/net/athebyne/exclusions_lib/predicates/OverlapsStructureBlockPredicate.java
+++ b/src/main/java/net/athebyne/exclusions_lib/predicates/OverlapsStructureBlockPredicate.java
@@ -1,81 +1,82 @@
 package net.athebyne.exclusions_lib.predicates;
 
-import com.mojang.serialization.Codec;
+import com.mojang.serialization.*;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import net.minecraft.registry.Registry;
-import net.minecraft.registry.RegistryCodecs;
-import net.minecraft.registry.RegistryKeys;
-import net.minecraft.registry.entry.RegistryEntry;
-import net.minecraft.registry.entry.RegistryEntryList;
-import net.minecraft.structure.StructurePiece;
-import net.minecraft.structure.StructureStart;
+import net.athebyne.exclusions_lib.ExclusionsLib;
+import net.minecraft.registry.*;
+import net.minecraft.registry.entry.*;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.structure.*;
 import net.minecraft.util.math.*;
 import net.minecraft.world.StructureWorldAccess;
+import net.minecraft.world.chunk.ChunkStatus;
 import net.minecraft.world.gen.StructureAccessor;
-import net.minecraft.world.gen.blockpredicate.BlockPredicate;
-import net.minecraft.world.gen.blockpredicate.BlockPredicateType;
+import net.minecraft.world.gen.blockpredicate.*;
 import net.minecraft.world.gen.structure.Structure;
-import net.athebyne.exclusions_lib.*;
-import org.apache.commons.lang3.mutable.MutableBoolean;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-
 public class OverlapsStructureBlockPredicate implements BlockPredicate {
 
-    public static final Codec<OverlapsStructureBlockPredicate> CODEC = RecordCodecBuilder.create((instance) -> instance.group(Vec3i.createOffsetCodec(16).optionalFieldOf("offset", BlockPos.ORIGIN).forGetter((predicate) -> predicate.offset),
-            RegistryCodecs.entryList(RegistryKeys.STRUCTURE).optionalFieldOf("structures").forGetter(OverlapsStructureBlockPredicate::structure),
-            Codec.intRange(0, 32).optionalFieldOf("range", 0).forGetter((predicate) -> predicate.range)).apply(instance, OverlapsStructureBlockPredicate::new));
+    public static final MapCodec<OverlapsStructureBlockPredicate> CODEC = RecordCodecBuilder.mapCodec(
+            (instance) ->
+                    instance.group(
+                            Vec3i.createOffsetCodec(16).optionalFieldOf("offset", BlockPos.ORIGIN).forGetter((predicate) -> predicate.offset),
+                            RegistryCodecs.entryList(RegistryKeys.STRUCTURE).optionalFieldOf("structures").forGetter(OverlapsStructureBlockPredicate::structure),
+                            Codec.intRange(0, 32).optionalFieldOf("range", 0).forGetter((predicate) -> predicate.range)
+                    ).apply(instance, OverlapsStructureBlockPredicate::new)
+    );
 
     private final Vec3i offset;
     private final int range;
+    private final List<Structure> structures;
+
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     private final Optional<RegistryEntryList<Structure>> rawStructures;
-    private final Optional<List<Structure>> structures;
-    public OverlapsStructureBlockPredicate(Vec3i offset,  Optional<RegistryEntryList<Structure>> structures, int range) {
+
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    public OverlapsStructureBlockPredicate(Vec3i offset, Optional<RegistryEntryList<Structure>> structures, int range) {
         this.rawStructures = structures;
-        if (structures.isEmpty()) {
-            this.structures = Optional.empty();
-        } else {
-            this.structures = Optional.of(structures.get().stream().map(RegistryEntry::value).collect(Collectors.toList()));
-        }
+        this.structures = structures
+                .map(s -> s.stream().map(RegistryEntry::value).collect(Collectors.toList()))
+                .orElse(null);
         this.offset = offset;
         this.range = range;
 
     }
+    
     public boolean test(StructureWorldAccess structureWorldAccess, BlockPos blockPos) {
-        StructureAccessor accessor = structureWorldAccess.toServerWorld().getStructureAccessor();
+        ServerWorld world = structureWorldAccess.toServerWorld();
+        StructureAccessor accessor = world.getStructureAccessor();
         BlockPos blockPosOffset = blockPos.add(this.offset);
-        BlockBox exclusionZone = new BlockBox(blockPosOffset.getX() - this.range, blockPosOffset.getY() - this.range, blockPosOffset.getZ() - this.range,blockPosOffset.getX() + this.range, blockPosOffset.getY() + this.range, blockPosOffset.getZ() + this.range);
-        for(var struct : accessor.getStructureReferences(blockPosOffset).entrySet())
-        {
-            if(this.structures.isPresent() && !this.structures.get().contains(struct.getKey()))
-            {
-                continue;
-            }
-            Predicate<StructureStart> predicate = start -> {
-                for (StructurePiece piece : start.getChildren()) {
-                    if (piece.getBoundingBox().intersects(exclusionZone)) {
-                        return true;
-                    }
-                }
-                return false;
-            };
-
-            MutableBoolean overlappingBox = new MutableBoolean(false);
-            accessor.acceptStructureStarts(struct.getKey(), struct.getValue(), (start) -> {
-                if (overlappingBox.isFalse() && predicate.test(start)) {
-                    overlappingBox.setTrue();
-                }
-            });
-
-            if (overlappingBox.isTrue()) {
-                return true;
+        Predicate<StructureStart> predicate = makePredicate(blockPosOffset);
+        for (var struct : accessor.getStructureReferences(blockPosOffset).entrySet()) {
+            if (this.structures != null && !this.structures.contains(struct.getKey())) continue;
+            for (long pos : struct.getValue()) {
+                ChunkSectionPos sectionPos = ChunkSectionPos.from(new ChunkPos(pos), world.getBottomSectionCoord());
+                StructureStart start = accessor.getStructureStart(
+                        sectionPos, struct.getKey(), world.getChunk(sectionPos.getSectionX(), sectionPos.getSectionZ(), ChunkStatus.STRUCTURE_STARTS)
+                );
+                if (start != null && start.hasChildren() && predicate.test(start)) return true;
             }
         }
         return false;
+    }
+
+    private @NotNull Predicate<StructureStart> makePredicate(BlockPos blockPosOffset) {
+        final BlockBox exclusionZone = new BlockBox(
+                blockPosOffset.getX() - this.range, blockPosOffset.getY() - this.range, blockPosOffset.getZ() - this.range,
+                blockPosOffset.getX() + this.range, blockPosOffset.getY() + this.range, blockPosOffset.getZ() + this.range
+        );
+	    return start -> {
+	        for (StructurePiece piece : start.getChildren())
+	            if (piece.getBoundingBox().intersects(exclusionZone)) return true;
+	        return false;
+	    };
     }
 
     public Optional<RegistryEntryList<Structure>> structure() {


### PR DESCRIPTION
Port to 1.21.1. All mixins mixin, everything is good.
The only needed changes were:
* Change one usage of `new Identifier` to `Identifier.of`
* Change the type of the `CODEC` field in `OverlapsStructureBlockPredicate` from `Codec` to `MapCodec`, and change the `RecordCodecBuilder.create` call to `RecordCodecBuilder.mapCodec`.
Other changes are simply random formatting changes. You are free to disregard this PR and implement just the needed changes if you disagree with my design choices.